### PR TITLE
loosen upper bound on base

### DIFF
--- a/verbalexpressions.cabal
+++ b/verbalexpressions.cabal
@@ -14,6 +14,6 @@ cabal-version:       >=1.8
 
 library
   exposed-modules:     Text.Regex.VerbalExpressions
-  build-depends:       base ==4.6.*,
+  build-depends:       base > 4.6 && < 4.9,
                        regex-pcre
   ghc-options:         -Wall


### PR DESCRIPTION
This seems to work fine with the rc1 of the new ghc-7.10 which uses base-4.8.0.0  No troubles arose from e.g the Applicative-Monad Proposal.  I notice by the way that if one uses the flipped apply, `&`, from the different lens libraries - also in Data.Function in the new base, there is a certain charm to an example like:

      let expr =  verEx  
          & searchGlobal 
          & startOfLine  
          & find "http"   
          & possibly "s"  
          & find "://"  
          & possibly "www"
          & anythingBut " " 
          & endOfLine

rather than


      let expr = searchGlobal >>>
              startOfLine     >>>
              find "http"     >>>
              possibly "s"    >>>
              find "://"      >>>
              possibly "www"  >>>
              anythingBut " " >>>
              endOfLine
              $ verEx

but it's just an aesthetic question.